### PR TITLE
Update for Angular 4 and TypeScript 2.3

### DIFF
--- a/lib/pubnub-angular2.d.ts
+++ b/lib/pubnub-angular2.d.ts
@@ -2,7 +2,7 @@ import {Wrapper} from "./wrapper";
 export declare class PubNubAngular {
     constructor();
     getInstance(instanceName: string): Wrapper;
-    init(initConfig: Object);
+    init(initConfig: Object): any;
     subscribe(args: Object): void;
     unsubscribe(args: Object): void;
     unsubscribeAll(): void;

--- a/lib/wrapper.d.ts
+++ b/lib/wrapper.d.ts
@@ -2,7 +2,7 @@ export declare class Wrapper {
     constructor();
     getLabel(): string;
     getOriginalInstance(): any;
-    init(initConfig: Object);
+    init(initConfig: Object): any;
     subscribe(args: Object): void;
     unsubscribe(args: Object): void;
     unsubscribeAll(): void;

--- a/src/declaration_files/pubnub-angular2.d.ts
+++ b/src/declaration_files/pubnub-angular2.d.ts
@@ -2,7 +2,7 @@ import {Wrapper} from "./wrapper";
 export declare class PubNubAngular {
     constructor();
     getInstance(instanceName: string): Wrapper;
-    init(initConfig: Object);
+    init(initConfig: Object): any;
     subscribe(args: Object): void;
     unsubscribe(args: Object): void;
     unsubscribeAll(): void;

--- a/src/declaration_files/wrapper.d.ts
+++ b/src/declaration_files/wrapper.d.ts
@@ -2,7 +2,7 @@ export declare class Wrapper {
     constructor();
     getLabel(): string;
     getOriginalInstance(): any;
-    init(initConfig: Object);
+    init(initConfig: Object): any;
     subscribe(args: Object): void;
     unsubscribe(args: Object): void;
     unsubscribeAll(): void;


### PR DESCRIPTION
Pubnub-Angular2 won't compile on TypeScript 2.3 without these modifications to the definition files. I made my best guess for `init` to return `any` since it's supposed to create a PubNub object. These are the errors I get below:

```node_modules/pubnub-angular2/lib/pubnub-angular2.d.ts(5,5): error TS7010: 'init', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/pubnub-angular2/lib/wrapper.d.ts(5,5): error TS7010: 'init', which lacks return-type annotation, implicitly has an 'any' return type.```